### PR TITLE
Python 3 support

### DIFF
--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,62 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Pycharm files
+.DS_Store
+.idea
+
 # C extensions
 *.so
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -10,4 +10,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 5000, host: 5000
+  config.vm.network "forwarded_port", guest: 5432, host: 5432
 end

--- a/vagrant/forum/forum.py
+++ b/vagrant/forum/forum.py
@@ -7,6 +7,7 @@ import forumdb
 
 # Other modules used to run a web server.
 import cgi
+import urllib
 from wsgiref.simple_server import make_server
 from wsgiref import util
 
@@ -69,7 +70,7 @@ def Post(env, resp):
     # If length is zero, post is empty - don't save it.
     if length > 0:
         postdata = input.read(length)
-        fields = cgi.parse_qs(postdata)
+        fields = urllib.parse.prase_qs(postdata)
         content = fields['content'][0]
         # If the post is just whitespace, don't save it.
         content = content.strip()
@@ -102,6 +103,6 @@ def Dispatcher(env, resp):
 
 # Run this bad server only on localhost!
 httpd = make_server('', 8000, Dispatcher)
-print "Serving HTTP on port 8000..."
+print("Serving HTTP on port 8000...")
 httpd.serve_forever()
 

--- a/vagrant/forum/forum.py
+++ b/vagrant/forum/forum.py
@@ -22,7 +22,7 @@ HTML_WRAP = '''\
       textarea { width: 400px; height: 100px; }
       div.post { border: 1px solid #999;
                  padding: 10px 10px;
-		 margin: 10px 20%%; }
+                 margin: 10px 20%%; }
       hr.postbound { width: 50%%; }
       em.date { color: #999 }
     </style>
@@ -44,12 +44,13 @@ POST = '''\
     <div class=post><em class=date>%(time)s</em><br>%(content)s</div>
 '''
 
+
 ## Request handler for main page
 def View(env, resp):
-    '''View is the 'main page' of the forum.
+    """View is the 'main page' of the forum.
 
     It displays the submission form and the previously posted messages.
-    '''
+    """
     # get posts from database
     posts = forumdb.GetAllPosts()
     # send results
@@ -57,13 +58,14 @@ def View(env, resp):
     resp('200 OK', headers)
     return [HTML_WRAP % ''.join(POST % p for p in posts)]
 
+
 ## Request handler for posting - inserts to database
 def Post(env, resp):
-    '''Post handles a submission of the forum's form.
-  
+    """Post handles a submission of the forum's form.
+
     The message the user posted is saved in the database, then it sends a 302
     Redirect back to the main page so the user can see their new post.
-    '''
+    """
     # Get post content
     input = env['wsgi.input']
     length = int(env.get('CONTENT_LENGTH', 0))
@@ -80,24 +82,26 @@ def Post(env, resp):
     # 302 redirect back to the main page
     headers = [('Location', '/'),
                ('Content-type', 'text/plain')]
-    resp('302 REDIRECT', headers) 
+    resp('302 REDIRECT', headers)
     return ['Redirecting']
+
 
 ## Dispatch table - maps URL prefixes to request handlers
 DISPATCH = {'': View,
             'post': Post,
-	    }
+            }
+
 
 ## Dispatcher forwards requests according to the DISPATCH table.
 def Dispatcher(env, resp):
-    '''Send requests to handlers based on the first path component.'''
+    """Send requests to handlers based on the first path component."""
     page = util.shift_path_info(env)
     if page in DISPATCH:
         return DISPATCH[page](env, resp)
     else:
         status = '404 Not Found'
         headers = [('Content-type', 'text/plain')]
-        resp(status, headers)    
+        resp(status, headers)
         return ['Not Found: ' + page]
 
 
@@ -105,4 +109,3 @@ def Dispatcher(env, resp):
 httpd = make_server('', 8000, Dispatcher)
 print("Serving HTTP on port 8000...")
 httpd.serve_forever()
-

--- a/vagrant/forum/forumdb.py
+++ b/vagrant/forum/forumdb.py
@@ -3,29 +3,50 @@
 # 
 
 import time
+import psycopg2
 
-## Database connection
+# Database connection
+try:
+    # "postgresql://vagrant:vagrant@localhost/forum"
+    conn = psycopg2.connect("dbname=forum")
+except psycopg2.Error as e:
+    print("Error: Unable to connect to the database", e)
+    exit(-1)
+cur = conn.cursor()
 DB = []
 
-## Get posts from database.
+# Get posts from database.
 def GetAllPosts():
-    '''Get all the posts from the database, sorted with the newest first.
+    """Get all the posts from the database, sorted with the newest first.
 
     Returns:
       A list of dictionaries, where each dictionary has a 'content' key
       pointing to the post content, and 'time' key pointing to the time
       it was posted.
-    '''
+    """
+    print('Connecting')
+    cur.execute('''
+     SELECT * FROM posts
+     ''')
+    DB = cur.fetchall()
+    print(DB)
     posts = [{'content': str(row[1]), 'time': str(row[0])} for row in DB]
     posts.sort(key=lambda row: row['time'], reverse=True)
     return posts
 
-## Add a post to the database.
+
+# Add a post to the database.
 def AddPost(content):
-    '''Add a new post to the database.
+    """Add a new post to the database.
 
     Args:
       content: The text content of the new post.
-    '''
+    """
     t = time.strftime('%c', time.localtime())
     DB.append((t, content))
+
+
+print('Calling function')
+GetAllPosts()
+
+conn.close()

--- a/vagrant/forum/forumdb.py
+++ b/vagrant/forum/forumdb.py
@@ -42,8 +42,9 @@ def AddPost(content):
     Args:
       content: The text content of the new post.
     """
-    t = time.strftime('%c', time.localtime())
-    DB.append((t, content))
+    insert_format = 'INSERT INTO posts VALUE {}'
+    cur.execute(insert_format.format(content))
+    cur.commit()
 
 
 print('Calling function')


### PR DESCRIPTION
Minor changes to allow it to run on python 3x
Converted docstrings to follow [PEP 0257](https://www.python.org/dev/peps/pep-0257/)
Removed the deprecated `cgi.parse_qs(postdata)` to use the `urllib.parse.parse_qs(postdata)` which it seems to be doing already
>  cgi.parse(fp=None, environ=os.environ, keep_blank_values=False, strict_parsing=False)
> Parse a query in the environment or from a file (the file defaults to sys.stdin). The keep_blank_values > and strict_parsing parameters are passed to urllib.parse.parse_qs() unchanged.
