### PR TITLE
Install latest version of Pip, instead of distribution version

### DIFF
--- a/vagrant/pg_config.sh
+++ b/vagrant/pg_config.sh
@@ -1,7 +1,8 @@
 apt-get -qqy update
 apt-get -qqy install postgresql python-psycopg2
 apt-get -qqy install python-flask python-sqlalchemy
-apt-get -qqy install python-pip
+wget https://bootstrap.pypa.io/get-pip.py
+python ./get-pip.py
 pip install bleach
 pip install oauth2client
 pip install requests

--- a/vagrant/pg_config.sh
+++ b/vagrant/pg_config.sh
@@ -1,8 +1,10 @@
 apt-get -qqy update
 apt-get -qqy install postgresql python-psycopg2
 apt-get -qqy install python-flask python-sqlalchemy
-wget https://bootstrap.pypa.io/get-pip.py
-python ./get-pip.py
+apt-get -qqy install python-pip
+pip install packaging
+pip install appdirs
+pip install -U six
 pip install bleach
 pip install oauth2client
 pip install requests


### PR DESCRIPTION
## Issue
The Ubuntu distribution version of Pip no longer works (complains about module `packaging` missing when running any `pip` command).

## How to replicate the issue
Clone a fresh copy of the repository. Do `vagrant up`, then `vagrant ssh`. Try to run the `pip` command and you will experience the above error.

## Solution
The solution is to install the very latest version of Pip instead. This also fixes issues with the dependencies for the Bleach package version 2.0.0.

The solution and further discussion of this issue was found here: https://github.com/pypa/setuptools/issues/937
