### PR TITLE
Fix for windows users with wrong host_ip

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,9 +3,9 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial32"
-  config.vm.network "forwarded_port", guest: 8000, host: 8000
-  config.vm.network "forwarded_port", guest: 8080, host: 8080
-  config.vm.network "forwarded_port", guest: 5000, host: 5000
+  config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 5000, host: 5000, host_ip: "127.0.0.1"
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
     apt-get upgrade


### PR DESCRIPTION
Users on windows has reported that they cannot get vagrant up and running because of a bug in Vagrant not being able to use the default `0.0.0.0`-ip for localhost. By using `127.0.0.1` instead, this works out ok.