### PR TITLE
Update Vagrantfile to use bento box.

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,10 +2,16 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial32"
+  config.vm.box = "bento/ubuntu-16.04-i386"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 5000, host: 5000, host_ip: "127.0.0.1"
+
+  # Work around disconnected virtual network cable.
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+  end
+
   config.vm.provision "shell", inline: <<-SHELL
     apt-get -qqy update
     apt-get -qqy upgrade


### PR DESCRIPTION
Moving to bento/ubuntu-16.04-i386 per https://udacity.atlassian.net/browse/WEBND-372.

Added workaround for known bug with network initialization.