### PR TITLE
fix: add back installation of requests package

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -24,12 +24,12 @@ Vagrant.configure("2") do |config|
     apt-get -qqy install python3 python3-pip
     pip3 install --upgrade pip
     pip3 install flask packaging oauth2client redis passlib flask-httpauth
-    pip3 install sqlalchemy flask-sqlalchemy psycopg2 bleach
+    pip3 install sqlalchemy flask-sqlalchemy psycopg2 bleach requests
 
     apt-get -qqy install python python-pip
     pip2 install --upgrade pip
     pip2 install flask packaging oauth2client redis passlib flask-httpauth
-    pip2 install sqlalchemy flask-sqlalchemy psycopg2 bleach
+    pip2 install sqlalchemy flask-sqlalchemy psycopg2 bleach requests
 
     su postgres -c 'createuser -dRS vagrant'
     su vagrant -c 'createdb'


### PR DESCRIPTION
The Python requests package is needed on the course, but is not a requirement of any other package, so does not get installed.

This PL explicitly installs the `requests` package, as was done in the old `pg_config.sh` file.