### PR TITLE
fix: Set Bento box version to last working version

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,6 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-16.04-i386"
+  config.vm.box_version = "= 2.3.5"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 5000, host: 5000, host_ip: "127.0.0.1"


### PR DESCRIPTION
The latest version of the Bento box caused the file sharing
to break, so fix the version to the last known working version.
This can be updated to a later version, once it has been fully
tested.

See this forum post for more discussion of the error this PL solves:

* https://discussions.udacity.com/t/vagrant-folder-not-mounted-after-installation/322884