### PR TITLE
3 fixes related to vagrant box  and some linux packages

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -27,12 +27,12 @@ Vagrant.configure("2") do |config|
     apt-get -qqy install python3 python3-pip
     pip3 install --upgrade pip
     pip3 install flask packaging oauth2client redis passlib flask-httpauth
-    pip3 install sqlalchemy flask-sqlalchemy psycopg2 bleach requests
+    pip3 install sqlalchemy flask-sqlalchemy psycopg2-binary bleach requests
 
     apt-get -qqy install python python-pip
     pip2 install --upgrade pip
     pip2 install flask packaging oauth2client redis passlib flask-httpauth
-    pip2 install sqlalchemy flask-sqlalchemy psycopg2 bleach requests
+    pip2 install sqlalchemy flask-sqlalchemy psycopg2-binary bleach requests
 
     su postgres -c 'createuser -dRS vagrant'
     su vagrant -c 'createdb'

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
-  config.vm.box = "bento/ubuntu-16.04-i386"
+  config.vm.box = "bento/ubuntu-16.04"
   config.vm.box_version = "= 2.3.5"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure("2") do |config|
   Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
   config.vm.box = "bento/ubuntu-16.04"
   config.vm.box_version = "= 2.3.5"
+  config.vm.synced_folder ".", "/vagrant"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 5000, host: 5000, host_ip: "127.0.0.1"


### PR DESCRIPTION

- Change the box template to be "bento/ubuntu-16.04". No need of i386.
- It is expected that vagrant mount the folder on "/vagrant" in the guest automatically. However, it does not work and the fix is to do that explicitly (synced_folder)

-  psycopg2 is renamed to psycopg2-binary. It should be considered with "apt-get install"