### PR TITLE
fix: Remove default server URL setting

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,7 +2,6 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
   config.vm.box = "bento/ubuntu-16.04"
   config.vm.box_version = "= 2.3.5"
   config.vm.synced_folder ".", "/vagrant"


### PR DESCRIPTION
Now that Vagrant 2.0.3 is out, the original issue is resolved. However, this line now causes `vagrant up` to fail on the latest version of Vagrant.

Fixes #90, #85