### PR TITLE
Update Vagrantfile

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
 
     # Work around https://github.com/chef/bento/issues/661
     # apt-get -qqy upgrade
-    DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+    DEBIAN_FRONTEND=noninteractive apt-get -qy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 
     apt-get -qqy install make zip unzip postgresql
 


### PR DESCRIPTION
Previously, the installation of grub-pc may fail due to lack of interac-
tivity. Passing -y was insufficient in silencing, but passing -q along
with it allowed the installation to proceed as planned.