### PR TITLE
Update Vagrantfile - python2 rsa

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure("2") do |config|
     pip2 install --upgrade pip
     pip2 install flask packaging oauth2client redis passlib flask-httpauth
     pip2 install sqlalchemy flask-sqlalchemy psycopg2-binary bleach requests
+    pip2 install --force rsa
 
     su postgres -c 'createuser -dRS vagrant'
     su vagrant -c 'createdb'


### PR DESCRIPTION
Force reinstallation of python2 rsa

**The problem:**
```
vagrant@vagrant:~$ python -c "import rsa; print rsa.__version__"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/rsa/__init__.py", line 24, in <module>
    from rsa.key import newkeys, PrivateKey, PublicKey
  File "/usr/local/lib/python2.7/dist-packages/rsa/key.py", line 1
SyntaxError: Non-ASCII character '\xc3' in file /usr/local/lib/python2.7/dist-packages/rsa/key.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

This problem also arises when running [views.py](https://github.com/udacity/APIs/blob/master/Lesson_4/10_Adding%20OAuth%202.0%20for%20Authentication/views.py)   from course APIs - ud388

I tried: `apt upgrade`, restart, and finally `pip2 install --upgrade rsa` unsuccessfully.

**The solution** is to force the reinstallation of python2 rsa module.
I propose to perform it in the Vagrantfile in this PR.