### PR TITLE
Updated box version to latest 202010.24.0

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-16.04-i386"
-  config.vm.box_version = "= 2.3.5"
+  config.vm.box_version = "= 202010.24.0"
   config.vm.synced_folder ".", "/vagrant"
   config.vm.network "forwarded_port", guest: 8000, host: 8000, host_ip: "127.0.0.1"
   config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"


### PR DESCRIPTION
Version `2.3.5` doesn't exist on `https://app.vagrantup.com/bento/boxes/ubuntu-16.04`